### PR TITLE
Update TIP-20: Add network ID to essence

### DIFF
--- a/tips/TIP-0020/tip-0020.md
+++ b/tips/TIP-0020/tip-0020.md
@@ -93,6 +93,13 @@ The following table describes the entirety of a _Transaction Payload_ in its ser
             </td>
           </tr>
           <tr>
+            <td>Network ID</td>
+            <td>uint64</td>
+            <td>
+              The unique value denoting whether the message was meant for mainnet, testnet, or a private networks. The <code>Network ID</code> should usually match the corresponding field of the encapsulating message, but this is not enforced.
+            </td>
+          </tr>
+          <tr>
             <td>Inputs Count</td>
             <td>uint16</td>
             <td>The number of input entries.</td>
@@ -396,6 +403,7 @@ The following criteria defines whether a payload passes the syntactical validati
 
 * Essence:
   * `Transaction Type` value must denote a _Transaction Essence_.
+  * `Network ID` must match the value of the current network.
   * Inputs:
     * `Inputs Count` must be 0 < x ≤ `Max Inputs Count`.
     * For each input the following must be true:


### PR DESCRIPTION
This PR adds `Network ID` to the signed _Transaction Essence_. This provides a way to send transactions that work on mainnet, but not on a testnet or any private networks.